### PR TITLE
Update baps.yml

### DIFF
--- a/baps.yml
+++ b/baps.yml
@@ -246,7 +246,7 @@ dependencies:
     - tokenizers==0.13.3
     - tomli==2.0.1
     - torch==2.0.1
-    - torchaudio==0.8.1
+    - torchaudio
     - torchvision==0.15.2
     - tqdm==4.64.1
     - traceback2==1.4.0


### PR DESCRIPTION
I had to change the version of TorchAudio because it caused conflicts with other packages during the pip install process. This conflict prevented the successful installation of all dependencies. To resolve the issue, I removed the version requirement for TorchAudio in the YAML file, which allowed the installation to complete without further problems. 